### PR TITLE
Evaluate the RELEASE_TAG expression

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   cd:
     runs-on: ubuntu-latest
-    env:
-      RELEASE_TAG: ${GITHUB_REF##*/}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -17,6 +15,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF##*/}
 
       - name: Run tests
         run: sbt clean test
@@ -37,12 +39,12 @@ jobs:
           sbt "api / Docker / publish"
         env:
           DOCKER_PACKAGE: ${{ secrets.GCP_PROJECT_ID }}/api-template-prod
-
+          RELEASE_TAG: ${{ steps.get_version.outputs.VERSION }}
       - name: Deploy Cloud Run
         run: |
           gcloud run deploy api-template-prod \
           --region europe-west1 \
-          --image eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/api-template-prod:${{ env.RELEASE_TAG }} \
+          --image eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/api-template-prod:${{ steps.get_version.outputs.VERSION }} \
           --platform managed \
           --allow-unauthenticated \
           --cpu 1000m --memory 512Mi --max-instances 1 \


### PR DESCRIPTION
Experimented on a local repo, had the same result as before. But it works using the previously proposed get_version step evaluating the expression.
About why it works on account-api side and not here, here's a test case : 

```yaml 
jobs:
  cd:
    runs-on: ubuntu-latest
    env:
      RELEASE_TAG: ${GITHUB_REF##*/}
    steps:
      - name: Checkout
        uses: actions/checkout@v2

      - name: Set up JDK
        uses: actions/setup-java@v1
        with:
          java-version: 1.11

      - name: Get the version
        id: get_version
        run: echo ::set-output name=VERSION::${GITHUB_REF##*/}

      - name: Get the version from env
        id: get_version_from_env
        run: echo ::set-output name=VERSION::${{ env.RELEASE_TAG }}

      - name: Echo
        run: echo "Hello world ${{ env.RELEASE_TAG }} - ${{ steps.get_version_from_env.outputs.VERSION }} - ${{ steps.get_version.outputs.VERSION }}"

      - name: Build Docker Image
        run: |
          sbt "api / Docker / publishLocal"
        env:
          DOCKER_PACKAGE: ${{ secrets.GCP_PROJECT_ID }}/api-template-prod
          RELEASE_TAG: ${{ steps.get_version.outputs.VERSION }}  ## this works !
```

CI tell us that the Echo step evaluates : 
 `echo "Hello world ${GITHUB_REF##*/} - 1.1.6 - 1.1.6"`
and returns 
`Hello world 1.1.6 - 1.1.6 - 1.1.6`

so it's really just a matter of evaluating the expression

Account-api works because the RELEASE_TAG env is used in a "run" step