### PR TITLE
Provide missing sl4j implementation: logback

### DIFF
--- a/project/Librairies.scala
+++ b/project/Librairies.scala
@@ -65,7 +65,8 @@ object Librairies {
   )
 
   val logging = Seq(
-    "dev.zio" %% "zio-logging-slf4j" % "0.5.13"
+    "dev.zio" %% "zio-logging-slf4j" % "0.5.13",
+    "ch.qos.logback" % "logback-classic" % "1.2.6"
   )
 
   val configurations = Seq(


### PR DESCRIPTION
While playing with this template I got the following error:
```
[info] running io.conduktor.api.ApiTemplateApp 
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder"
```
Don't know if this wanted from you to let the sl4j implementation choice up to the final user. 
If not here my PR.
